### PR TITLE
Update configuration Constructor to get host link

### DIFF
--- a/application.example.properties
+++ b/application.example.properties
@@ -15,3 +15,4 @@ mailchimp.list.name=
 #  - permanent.test.2@<mailchimp.test.domain> - subscribed
 #  - permanent.test.3@<mailchimp.test.domain> - subscribed
 mailchimp.test.domain=
+mailchimp.test.host=

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -7,10 +7,7 @@ public class MailchimpClientConfiguration {
     private static final String SCHEME = "https";
     private static final int PORT = 443;
     private static final String MAILCHIMP_API_VERSION_URI = "/3.0/";
-    private static final String API_KEY_SPLITTER = "-";
-
     private final String apiKey;
-
     private final String baseUri;
     private final String host;
 

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -6,7 +6,6 @@ package uk.ac.stfc.facilities.mailing.mailchimp;
 public class MailchimpClientConfiguration {
     private static final String SCHEME = "https";
     private static final int PORT = 443;
-    private static final String MAILCHIMP_API_BASE_HOST = "proxy-api.facilities.rl.ac.uk/mailchimp";
     private static final String MAILCHIMP_API_VERSION_URI = "/3.0/";
     private static final String API_KEY_SPLITTER = "-";
 
@@ -21,10 +20,10 @@ public class MailchimpClientConfiguration {
      *
      * @param apiKey the API key for Mailchimp.
      */
-    public MailchimpClientConfiguration(String apiKey) {
+    public MailchimpClientConfiguration(String apiKey,String host) {
         this.apiKey = apiKey;
-        this.host = MAILCHIMP_API_BASE_HOST;
-        this.baseUri = SCHEME + "://" + MAILCHIMP_API_BASE_HOST;
+        this.host = host;
+        this.baseUri = SCHEME + "://" + this.host + MAILCHIMP_API_VERSION_URI;
     }
 
     public String getApiKey() {

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -16,6 +16,7 @@ public class MailchimpClientConfiguration {
      * contains all of the connection information for Mailchimp.
      *
      * @param apiKey the API key for Mailchimp.
+     * @param host the Mailchimp Host link.
      */
     public MailchimpClientConfiguration(String apiKey,String host) {
         this.apiKey = apiKey;

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -24,7 +24,7 @@ public class MailchimpClientConfiguration {
     public MailchimpClientConfiguration(String apiKey) {
         this.apiKey = apiKey;
         this.host = MAILCHIMP_API_BASE_HOST;
-        this.baseUri = SCHEME + "://" + MAILCHIMP_API_VERSION_URI;
+        this.baseUri = SCHEME + "://" + MAILCHIMP_API_BASE_HOST;
     }
 
     public String getApiKey() {

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -4,24 +4,19 @@ package uk.ac.stfc.facilities.mailing.mailchimp;
  * Configuration for the Mailchimp client.
  */
 public class MailchimpClientConfiguration {
-    private static final String SCHEME = "https";
-    private static final int PORT = 443;
-    private static final String MAILCHIMP_API_VERSION_URI = "/3.0/";
     private final String apiKey;
     private final String baseUri;
-    private final String host;
 
     /**
      * Creates the configuration from the Mailchimp API key which
      * contains all of the connection information for Mailchimp.
      *
      * @param apiKey the API key for Mailchimp.
-     * @param host the Mailchimp Host link.
+     * @param baseUri the Mailchimp baseUri.
      */
-    public MailchimpClientConfiguration(String apiKey,String host) {
+    public MailchimpClientConfiguration(String apiKey,String baseUri) {
         this.apiKey = apiKey;
-        this.host = host;
-        this.baseUri = SCHEME + "://" + this.host + MAILCHIMP_API_VERSION_URI;
+        this.baseUri = baseUri;
     }
 
     public String getApiKey() {
@@ -32,15 +27,4 @@ public class MailchimpClientConfiguration {
         return baseUri;
     }
 
-    public String getHost() {
-        return host;
-    }
-
-    public String getScheme() {
-        return SCHEME;
-    }
-
-    public int getPort() {
-        return PORT;
-    }
 }

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -6,7 +6,7 @@ package uk.ac.stfc.facilities.mailing.mailchimp;
 public class MailchimpClientConfiguration {
     private static final String SCHEME = "https";
     private static final int PORT = 443;
-    private static final String MAILCHIMP_API_BASE_HOST = "api.mailchimp.com";
+    private static final String MAILCHIMP_API_BASE_HOST = "https://proxy-api.facilities.rl.ac.uk/mailchimp";
     private static final String MAILCHIMP_API_VERSION_URI = "/3.0/";
     private static final String API_KEY_SPLITTER = "-";
 

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientConfiguration.java
@@ -6,7 +6,7 @@ package uk.ac.stfc.facilities.mailing.mailchimp;
 public class MailchimpClientConfiguration {
     private static final String SCHEME = "https";
     private static final int PORT = 443;
-    private static final String MAILCHIMP_API_BASE_HOST = "https://proxy-api.facilities.rl.ac.uk/mailchimp";
+    private static final String MAILCHIMP_API_BASE_HOST = "proxy-api.facilities.rl.ac.uk/mailchimp";
     private static final String MAILCHIMP_API_VERSION_URI = "/3.0/";
     private static final String API_KEY_SPLITTER = "-";
 
@@ -23,9 +23,8 @@ public class MailchimpClientConfiguration {
      */
     public MailchimpClientConfiguration(String apiKey) {
         this.apiKey = apiKey;
-        String dataCenter = apiKey.split(API_KEY_SPLITTER)[1];
-        this.host = dataCenter + "." + MAILCHIMP_API_BASE_HOST;
-        this.baseUri = SCHEME + "://" + host + MAILCHIMP_API_VERSION_URI;
+        this.host = MAILCHIMP_API_BASE_HOST;
+        this.baseUri = SCHEME + "://" + MAILCHIMP_API_VERSION_URI;
     }
 
     public String getApiKey() {

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClient.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClient.java
@@ -62,7 +62,7 @@ class MailchimpInternalHttpClient {
         provider.setCredentials(AuthScope.ANY, credentials);
 
         AuthCache authCache = new BasicAuthCache();
-        authCache.put(new HttpHost( HttpHost.create(configuration.getBaseUrl())), new BasicScheme());
+        authCache.put(HttpHost.create(configuration.getBaseUrl()), new BasicScheme());
 
         HttpClientContext context = HttpClientContext.create();
 

--- a/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClient.java
+++ b/src/main/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClient.java
@@ -62,7 +62,7 @@ class MailchimpInternalHttpClient {
         provider.setCredentials(AuthScope.ANY, credentials);
 
         AuthCache authCache = new BasicAuthCache();
-        authCache.put(new HttpHost(configuration.getHost(), configuration.getPort(), configuration.getScheme()), new BasicScheme());
+        authCache.put(new HttpHost( HttpHost.create(configuration.getBaseUrl())), new BasicScheme());
 
         HttpClientContext context = HttpClientContext.create();
 

--- a/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientIT.java
+++ b/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpClientIT.java
@@ -67,8 +67,9 @@ public class MailchimpClientIT {
         properties.load(new FileInputStream(file));
 
         String mailchimpApiKey =  loadProperty(properties, "mailchimp.api.key");
+        String mailchimpHost =  loadProperty(properties, "mailchimp.test.host");
 
-        mailchimpClient = MailchimpClient.getInstance(new MailchimpClientConfiguration(mailchimpApiKey));
+        mailchimpClient = MailchimpClient.getInstance(new MailchimpClientConfiguration(mailchimpApiKey,mailchimpHost));
 
         listId = loadProperty(properties, "mailchimp.list.id");
 

--- a/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClientTest.java
+++ b/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClientTest.java
@@ -69,7 +69,7 @@ public class MailchimpInternalHttpClientTest {
 
     // dash is required in the api key
     private static final MailchimpClientConfiguration EXAMPLE_CONFIGURATION =
-            new MailchimpClientConfiguration("abcd-ab1");
+            new MailchimpClientConfiguration("abcd-ab1","devproxy-api.facilities.rl.ac.uk/mailchimp");
 
     private static final IOException EXPECTED_IO_EXCEPTION_CAUSE = new IOException("test");
     private static final String TEST_DTO_JSON = "{\"value\":\"hello world\"}";

--- a/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClientTest.java
+++ b/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClientTest.java
@@ -69,7 +69,7 @@ public class MailchimpInternalHttpClientTest {
 
     // dash is required in the api key
     private static final MailchimpClientConfiguration EXAMPLE_CONFIGURATION =
-            new MailchimpClientConfiguration("abcd-ab1","devproxy-api.facilities.rl.ac.uk/mailchimp/3.0");
+            new MailchimpClientConfiguration("abcd-ab1","devproxy-api.facilities.rl.ac.uk/mailchimp/3.0/");
 
     private static final IOException EXPECTED_IO_EXCEPTION_CAUSE = new IOException("test");
     private static final String TEST_DTO_JSON = "{\"value\":\"hello world\"}";

--- a/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClientTest.java
+++ b/src/test/java/uk/ac/stfc/facilities/mailing/mailchimp/MailchimpInternalHttpClientTest.java
@@ -69,7 +69,7 @@ public class MailchimpInternalHttpClientTest {
 
     // dash is required in the api key
     private static final MailchimpClientConfiguration EXAMPLE_CONFIGURATION =
-            new MailchimpClientConfiguration("abcd-ab1","devproxy-api.facilities.rl.ac.uk/mailchimp");
+            new MailchimpClientConfiguration("abcd-ab1","devproxy-api.facilities.rl.ac.uk/mailchimp/3.0");
 
     private static final IOException EXPECTED_IO_EXCEPTION_CAUSE = new IOException("test");
     private static final String TEST_DTO_JSON = "{\"value\":\"hello world\"}";


### PR DESCRIPTION
Closes #44 This PR updates the constructor to get the link.

The link would be passed by the consumer.

The reverse proxy has already been configured to access MailChimp.

https://github.com/isisbusapps/fba-reverse-proxy/blob/0aa3491e4980fed9f20cabe4a72eeae7173ae390/Apache24/conf/stfc/dev.conf#L66

https://github.com/isisbusapps/fba-reverse-proxy/blob/0aa3491e4980fed9f20cabe4a72eeae7173ae390/Apache24/conf/stfc/internalApiProxy-vhosts.conf#L149

**Please ensure the following boxes are ticked before asking for a review (tick to show they've been considered even if no action is needed):**
- [x] Link to close related issues
- [x] Created any necessary tests (unit / integration / BLAATs)
- [x] All tests passing (unit / integration / BLAATs)
- [x] SQL rollout and rollback included and tested
- [x] Release information for end users included
- [x] Labelled appropriately (`BISAppSettings Change`, `DB`, `WSDL`)
